### PR TITLE
Workflow job order and token

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,15 +43,17 @@ jobs:
     uses: ./.github/workflows/checks.yml
 
   build:
-    if: always() && needs.checks.result == 'success'
-    needs: checks
+    if: always() && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
+    needs: bump-version
     uses: ./.github/workflows/build.yml
     with:
       upload: true
 
   upload-to-heroku:
-    if: always() && needs.build.result == 'success'
-    needs: build
+    if: always() && needs.build.result == 'success' && needs.checks.result == 'success'
+    needs:
+      - build
+      - checks
     runs-on: ubuntu-latest
     environment: nhl-score-api
     steps:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,12 +13,8 @@ on:
           - major
 
 jobs:
-  checks:
-    uses: ./.github/workflows/checks.yml
-
   bump-version:
     if: ${{ inputs.version-bump != 'none' }}
-    needs: checks
     runs-on: ubuntu-latest
     environment: nhl-score-api
     steps:
@@ -26,7 +22,6 @@ jobs:
         with:
           # Fetch full history for version bumping with `lein release` that creates Git tags and commits
           fetch-depth: 0
-          token: ${{ secrets.TOKEN_BYPASS_REQUIRED_CHECKS }}
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -42,9 +37,14 @@ jobs:
       - name: Push to Git
         run: git push origin master --tags
 
-  build:
+  checks:
     if: always() && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
     needs: bump-version
+    uses: ./.github/workflows/checks.yml
+
+  build:
+    if: always() && needs.checks.result == 'success'
+    needs: checks
     uses: ./.github/workflows/build.yml
     with:
       upload: true

--- a/README.md
+++ b/README.md
@@ -840,9 +840,6 @@ The workflow requires these set in _Actions secrets and variables_ in the reposi
 
 - `HEROKU_API_KEY` repository secret: you can find this from the _API Key_ section in your Heroku account settings
 - `HEROKU_APP_NAME` repository variable: your app name in Heroku
-- `TOKEN_BYPASS_REQUIRED_CHECKS` repository secret: generate a [personal access token (classic)](https://github.com/settings/tokens) with full `repo` rights
-  - The user who owns the access token needs to be on the bypass list for required GitHub status checks (configured in the repository rulesets)
-  - It’s recommended to set an expirate date for the token, though this means it needs to be regenerated periodically
 
 ### Alternative deployment from development machine
 


### PR DESCRIPTION
Reorder deployment workflow jobs to create the version bump commit before checks and build, removing the bypass secret token.

---
<a href="https://cursor.com/background-agent?bcId=bc-db971603-19a8-4d34-a699-9ae51d402e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db971603-19a8-4d34-a699-9ae51d402e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the deployment workflow to create and push the version bump before validation and deployment, and removes the bypass token.
> 
> - Run `bump-version` first; make `checks` and `build` depend on it, and gate `upload-to-heroku` on successful `build` and `checks` (with `always()` safeguards)
> - Remove `TOKEN_BYPASS_REQUIRED_CHECKS` usage from workflow and its mention from `README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90a0a86823ec483f2903a701598cd7ac279279d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->